### PR TITLE
Fullscreen mode with SDL

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -18,7 +18,8 @@
 * Stay at home until explicitly leaving (with ESC)
 * More robust save file format. Future additions of items will not break
   existing savegames anymore
-* Toggle full screen with ALT-Enter on macOS and Windows
+* Toggle full screen mode with ALT-Enter (macOS and Windows)
+* Change font size while the game is running (macOS and Windows)
 * Switch Windows build to WIN64
 
 ### Fixed bugs:

--- a/Changelog.md
+++ b/Changelog.md
@@ -18,6 +18,7 @@
 * Stay at home until explicitly leaving (with ESC)
 * More robust save file format. Future additions of items will not break
   existing savegames anymore
+* Toggle full screen with ALT-Enter on macOS and Windows
 * Switch Windows build to WIN64
 
 ### Fixed bugs:

--- a/inc/config.h
+++ b/inc/config.h
@@ -1,6 +1,6 @@
 /*
  * config.h
- * Copyright (C) 2009-2020 Joachim de Groot <jdegroot@web.de>
+ * Copyright (C) 2009-2025 Joachim de Groot <jdegroot@web.de>
  *
  * NLarn is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -30,6 +30,7 @@ struct game_config {
     char *stats;
 #ifdef SDLPDCURSES
     int font_size;
+    gboolean fullscreen;
 #endif
     char *userdir;
     gboolean show_scores;

--- a/inc/display.h
+++ b/inc/display.h
@@ -179,7 +179,7 @@ int display_getch(WINDOW *win);
 
 #ifdef SDLPDCURSES
 /* toggle SDL fullscreen mode */
-void display_toggle_fullscreen();
+void display_toggle_fullscreen(gboolean toggle);
 #endif
 
 #endif

--- a/inc/display.h
+++ b/inc/display.h
@@ -177,5 +177,9 @@ void display_windows_show();
  */
 int display_getch(WINDOW *win);
 
+#ifdef SDLPDCURSES
+/* toggle SDL fullscreen mode */
+void display_toggle_fullscreen();
+#endif
 
 #endif

--- a/inc/display.h
+++ b/inc/display.h
@@ -180,6 +180,9 @@ int display_getch(WINDOW *win);
 #ifdef SDLPDCURSES
 /* toggle SDL fullscreen mode */
 void display_toggle_fullscreen(gboolean toggle);
+
+/* replace font at runtime */
+void display_change_font();
 #endif
 
 #endif

--- a/inc/extdefs.h
+++ b/inc/extdefs.h
@@ -1,6 +1,6 @@
 /*
- * nlarn.h
- * Copyright (C) 2009-2020 Joachim de Groot <jdegroot@web.de>
+ * extdefs.h
+ * Copyright (C) 2009-2025 Joachim de Groot <jdegroot@web.de>
  *
  * NLarn is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -29,6 +29,9 @@ extern const char *nlarn_version;
 
 /* the entire game */
 extern game *nlarn;
+
+/* game settings */
+extern struct game_config config;
 
 /* death jump buffer - used to return to the main loop when the player has died */
 extern jmp_buf nlarn_death_jump;

--- a/inc/game.h
+++ b/inc/game.h
@@ -35,7 +35,6 @@ typedef struct game
 {
     player *p;                  /* the player */
     map *maps[MAP_MAX];         /* the dungeon */
-    guint8 version;             /* save compatibility value */
     guint64 time_start;         /* start time */
     guint32 gtime;              /* turn count */
     guint8 difficulty;          /* game difficulty */

--- a/inc/game.h
+++ b/inc/game.h
@@ -30,6 +30,9 @@
 /* internal counter for save file compatibility */
 #define SAVEFILE_VERSION    28
 
+/* forward declarations */
+struct game_config;
+
 /* the world as we know it */
 typedef struct game
 {
@@ -90,14 +93,8 @@ typedef struct game
         player_stats_set: 1, /* the player's stats have been assigned */
         cure_dianthr_created: 1, /* the potion of cure dianthroritis is a unique item */
         wizard: 1, /* wizard mode */
-        fullvis: 1, /* show entire map in wizard mode */
-        autosave: 1; /* save the game when entering a new map */
+        fullvis: 1; /* show entire map in wizard mode */
 } game;
-
-
-/* forward declarations */
-
-struct game_config;
 
 
 /* function declarations */
@@ -148,7 +145,6 @@ void game_delete_savefile();
 #define game_difficulty(g) ((g)->difficulty)
 #define game_wizardmode(g) ((g)->wizard)
 #define game_fullvis(g)    ((g)->fullvis)
-#define game_autosave(g)   ((g)->autosave)
 
 #define game_turn(g)            ((g)->gtime)
 #define game_remaining_turns(g) (((g)->gtime > TIMELIMIT) ? 0 : TIMELIMIT - (g)->gtime)

--- a/lib/nlarn.hlp
+++ b/lib/nlarn.hlp
@@ -15,7 +15,7 @@ Running means moving into one direction until interrupted. `GREEN`g`end` or `GRE
 `GREEN`V`end`   voyage (travel) to a location on the level
 `GREEN`C`end`   continue travelling
 
-You can select the travel target by moving the cursor or by typing the desired feature's symbol (e.g. `GREEN`_`end` for an altar). Subsequent key presses will move the cursor around if there are more than one of the desired features on the level. When finished, press ENTER to start the journey. When a foe comes into sight, travelling will be aborted automatically and can be continued with `GREEN`C`end` when the enemy gets out of sight.
+You can select the travel target by moving the cursor or by typing the desired feature's symbol (e.g. `GREEN`_`end` for an altar). Subsequent key presses will move the cursor around if there are more than one of the desired features on the level. You can return the cursor to your character by pressing `GREEN`@`end`. When finished, press ENTER to start the journey. When a foe comes into sight, travelling will be aborted automatically and can be continued with `GREEN`C`end` when the enemy gets out of sight.
 
 
 `YELLOW`Other actions`end`

--- a/src/config.c
+++ b/src/config.c
@@ -465,6 +465,7 @@ void configure_defaults(const char *inifile)
                         if (val >= 6 && val <= 48)
                         {
                             config.font_size = val;
+                            display_change_font();
                         }
                         else
                         {

--- a/src/config.c
+++ b/src/config.c
@@ -310,9 +310,6 @@ void configure_defaults(const char *inifile)
         "\n"
         "Clear values with `GREEN`A`end`-`GREEN`D`end`\n";
 
-    struct game_config config = {};
-    parse_ini_file(inifile, &config);
-
     gboolean leaving = FALSE;
 
     while (!leaving)
@@ -482,11 +479,8 @@ void configure_defaults(const char *inifile)
         display_window_destroy(cwin);
     }
 
-    /* write back modified config */
+    /* write modified config */
     write_ini_file(inifile, &config);
-
-    /* clean up */
-    free_config(config);
 }
 
 void config_increase_difficulty(const char *inifile, const int new_difficulty)

--- a/src/config.c
+++ b/src/config.c
@@ -64,6 +64,9 @@ static const char *default_config_file =
     "# Font size for the game. Defaults to 18 when not defined.\n"
     "font-size=18\n"
     "\n"
+    "# Enable full screen mode for the game. Defaults to false.\n"
+    "fullscreen=false\n"
+    "\n"
 #endif
     "# Disable automatic saving when switching a level. Saving the game is\n"
     "# enabled by default, disable when it's too slow on your computer\n"
@@ -90,7 +93,7 @@ void parse_commandline(int argc, char *argv[], struct game_config *config)
         { "no-autosave", 'N', 0, G_OPTION_ARG_NONE,   &config->no_autosave,  "Disable autosave", NULL },
         { "wizard",      'w', 0, G_OPTION_ARG_NONE,   &config->wizard,       "Enable wizard mode", NULL },
 #ifdef SDLPDCURSES
-        { "font-size",   'S', 0, G_OPTION_ARG_INT,    &config->font_size,   "Set font size", NULL },
+        { "font-size",   'S', 0, G_OPTION_ARG_INT,    &config->font_size,    "Set font size", NULL },
 #endif
         { "userdir",     'D', 0, G_OPTION_ARG_FILENAME, &config->userdir,    "Alternate directory for config file and saved games", NULL },
         { "highscores",  'h', 0, G_OPTION_ARG_NONE,   &config->show_scores,  "Show highscores and exit", NULL },
@@ -154,6 +157,10 @@ gboolean parse_ini_file(const char *filename, struct game_config *config)
         int font_size = g_key_file_get_integer(ini_file, "nlarn", "font-size", &error);
         if (!config->font_size && !error) config->font_size = font_size;
         g_clear_error(&error);
+
+        gboolean fullscreen = g_key_file_get_boolean(ini_file, "nlarn", "fullscreen", &error);
+        if (!error) config->fullscreen = fullscreen;
+        g_clear_error(&error);
 #endif
     }
     else
@@ -190,7 +197,8 @@ void write_ini_file(const char *filename, struct game_config *config)
         g_key_file_set_value(kf,   "nlarn", "auto-pickup", config->auto_pickup ? config->auto_pickup : "");
         g_key_file_set_boolean(kf, "nlarn", "no-autosave", config->no_autosave);
 #ifdef SDLPDCURSES
-        g_key_file_set_integer(kf, "nlarn", "font-size", config->font_size);
+        g_key_file_set_integer(kf, "nlarn", "font-size",   config->font_size);
+        g_key_file_set_boolean(kf, "nlarn", "fullscreen",  config->fullscreen);
 #endif
     }
 
@@ -306,6 +314,7 @@ void configure_defaults(const char *inifile)
         "  `GREEN`e`end`) Autosave on map change - `YELLOW`%s`end`\n"
 #ifdef SDLPDCURSES
         "  `GREEN`f`end`) Configure font size    - `YELLOW`%d`end`\n"
+        "  `GREEN`g`end`) Full screen mode       - `YELLOW`%s`end`\n"
 #endif
         "\n"
         "Clear values with `GREEN`A`end`-`GREEN`D`end`\n";
@@ -344,6 +353,7 @@ void configure_defaults(const char *inifile)
                 config.no_autosave ? "no" : "yes"
 #ifdef SDLPDCURSES
                 , config.font_size
+                , config.fullscreen ? "yes" : "no"
 #endif
                 );
 
@@ -441,8 +451,8 @@ void configure_defaults(const char *inifile)
                 config.no_autosave = !config.no_autosave;
                 break;
 
-            /* font size */
 #ifdef SDLPDCURSES
+            /* font size */
             case 'f':
                 {
                     char *cval = g_strdup_printf("%d", config.font_size);
@@ -465,6 +475,11 @@ void configure_defaults(const char *inifile)
                         }
                     }
                 }
+                break;
+
+            /* fullscreen */
+            case 'g':
+                display_toggle_fullscreen(TRUE);
                 break;
 #endif
 

--- a/src/config.c
+++ b/src/config.c
@@ -127,7 +127,7 @@ gboolean parse_ini_file(const char *filename, struct game_config *config)
         /* ini file has been found, get values */
         /* clear error after each attempt as values need not to be defined */
         int difficulty = g_key_file_get_integer(ini_file, "nlarn", "difficulty", &error);
-        if (!config->difficulty && !error) config->difficulty = difficulty;
+        if (!error) config->difficulty = difficulty;
         g_clear_error(&error);
 
         gboolean no_autosave = g_key_file_get_boolean(ini_file, "nlarn", "no-autosave", &error);

--- a/src/config.c
+++ b/src/config.c
@@ -92,9 +92,6 @@ void parse_commandline(int argc, char *argv[], struct game_config *config)
         { "auto-pickup", 'a', 0, G_OPTION_ARG_STRING, &config->auto_pickup,  "Item types to pick up automatically, e.g. '$*+'", NULL },
         { "no-autosave", 'N', 0, G_OPTION_ARG_NONE,   &config->no_autosave,  "Disable autosave", NULL },
         { "wizard",      'w', 0, G_OPTION_ARG_NONE,   &config->wizard,       "Enable wizard mode", NULL },
-#ifdef SDLPDCURSES
-        { "font-size",   'S', 0, G_OPTION_ARG_INT,    &config->font_size,    "Set font size", NULL },
-#endif
         { "userdir",     'D', 0, G_OPTION_ARG_FILENAME, &config->userdir,    "Alternate directory for config file and saved games", NULL },
         { "highscores",  'h', 0, G_OPTION_ARG_NONE,   &config->show_scores,  "Show highscores and exit", NULL },
         { "version",     'v', 0, G_OPTION_ARG_NONE,   &config->show_version, "Show version information and exit", NULL },

--- a/src/config.c
+++ b/src/config.c
@@ -340,7 +340,7 @@ void configure_defaults(const char *inifile)
                 nbuf ? nbuf : undef,
                 gbuf ? gbuf : undef,
                 sbuf ? sbuf : undef,
-                abuf ? abuf: undef,
+                abuf ? abuf : undef,
                 config.no_autosave ? "no" : "yes"
 #ifdef SDLPDCURSES
                 , config.font_size

--- a/src/display.c
+++ b/src/display.c
@@ -28,6 +28,7 @@
 #endif
 
 #include "colours.h"
+#include "config.h"
 #include "display.h"
 #include "fov.h"
 #include "map.h"

--- a/src/display.c
+++ b/src/display.c
@@ -80,6 +80,15 @@ void display_init()
     g_setenv("PDC_ICON", icon_name, 1);
     g_free(icon_name);
 
+    /* If a font size was defined, export it to the environment
+     * before initialising PDCurses. */
+    if (config.font_size)
+    {
+        gchar size[4];
+        g_snprintf(size, 3, "%d", config.font_size);
+        g_setenv("PDC_FONT_SIZE", size, TRUE);
+    }
+
     /* Set the font - allow overriding this default */
     gchar *font_name = g_strdup_printf("%s/FiraMono-Medium.otf", nlarn_libdir);
     g_setenv("PDC_FONT", font_name, 0);

--- a/src/display.c
+++ b/src/display.c
@@ -98,6 +98,8 @@ void display_init()
     PDC_set_title(window_title);
     g_free(window_title);
 
+    display_toggle_fullscreen(FALSE);
+
     /* return modifier keys pressed with key */
     PDC_return_key_modifiers(TRUE);
 #endif
@@ -2875,11 +2877,14 @@ int display_getch(WINDOW *win) {
 }
 
 #ifdef SDLPDCURSES
-void display_toggle_fullscreen()
+void display_toggle_fullscreen(gboolean toggle)
 {
-    fullscreen = fullscreen == SDL_WINDOW_FULLSCREEN_DESKTOP
-        ? 0
-        : SDL_WINDOW_FULLSCREEN_DESKTOP;
+    if (toggle)
+        config.fullscreen = !config.fullscreen;
+
+    int fullscreen = config.fullscreen
+        ? SDL_WINDOW_FULLSCREEN_DESKTOP
+        : FALSE;
 
     SDL_SetWindowFullscreen(pdc_window, fullscreen);
 
@@ -3117,7 +3122,8 @@ static int display_window_move(display_window *dwin, int key)
 #ifdef SDLPDCURSES
     case 13: /* ENTER */
         if (PDC_get_key_modifiers() & PDC_KEY_MODIFIER_ALT)
-            display_toggle_fullscreen();
+            display_toggle_fullscreen(true);
+
         break;
 #endif
 

--- a/src/game.c
+++ b/src/game.c
@@ -1,6 +1,6 @@
 /*
  * game.c
- * Copyright (C) 2009-2018 Joachim de Groot <jdegroot@web.de>
+ * Copyright (C) 2009-2025 Joachim de Groot <jdegroot@web.de>
  *
  * NLarn is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -222,7 +222,7 @@ int game_save(game *g)
 
     save = cJSON_CreateObject();
 
-    cJSON_AddNumberToObject(save, "nlarn_version", g->version);
+    cJSON_AddNumberToObject(save, "nlarn_version", SAVEFILE_VERSION);
     cJSON_AddNumberToObject(save, "time_start", g->time_start);
     cJSON_AddNumberToObject(save, "gtime", g->gtime);
     cJSON_AddNumberToObject(save, "difficulty", g->difficulty);
@@ -566,7 +566,6 @@ static void game_new()
     /* game time handling */
     nlarn->gtime = 1;
     nlarn->time_start = time(NULL);
-    nlarn->version = SAVEFILE_VERSION;
 
     /* start a new diary */
     nlarn->log = log_new();
@@ -634,9 +633,9 @@ static gboolean game_load()
     gboolean compatible_version = FALSE;
     if (cJSON_GetObjectItem(save, "nlarn_version"))
     {
-        nlarn->version = cJSON_GetObjectItem(save, "nlarn_version")->valueint;
+        int sfv = cJSON_GetObjectItem(save, "nlarn_version")->valueint;
 
-        if (nlarn->version == SAVEFILE_VERSION)
+        if (sfv == SAVEFILE_VERSION)
             compatible_version = TRUE;
     }
 

--- a/src/game.c
+++ b/src/game.c
@@ -120,9 +120,6 @@ void game_init(struct game_config *config)
     /* allocate space for game structure */
     nlarn = g_malloc0(sizeof(game));
 
-    /* set autosave setting (default: TRUE) */
-    game_autosave(nlarn) = !config->no_autosave;
-
     if (!game_load())
     {
         /* set game parameters */

--- a/src/nlarn.c
+++ b/src/nlarn.c
@@ -840,6 +840,13 @@ static void mainloop()
             display_draw();
             break;
 
+#ifdef SDLPDCURSES
+        case 13: /* ENTER */
+            if (PDC_get_key_modifiers() & PDC_KEY_MODIFIER_ALT)
+                display_toggle_fullscreen();
+            break;
+#endif
+
             /* configure defaults */
         case 16: /* ^P */
             configure_defaults(nlarn_inifile);

--- a/src/nlarn.c
+++ b/src/nlarn.c
@@ -843,7 +843,8 @@ static void mainloop()
 #ifdef SDLPDCURSES
         case 13: /* ENTER */
             if (PDC_get_key_modifiers() & PDC_KEY_MODIFIER_ALT)
-                display_toggle_fullscreen();
+                display_toggle_fullscreen(TRUE);
+
             break;
 #endif
 

--- a/src/nlarn.c
+++ b/src/nlarn.c
@@ -272,16 +272,6 @@ static void nlarn_init(int argc, char *argv[])
     /* try to load settings from the configuration file */
     parse_ini_file(nlarn_inifile, &config);
 
-#ifdef SDLPDCURSES
-    /* If a font size was defined, export it to the environment
-     * before initialising PDCurses. */
-    if (config.font_size)
-    {
-        gchar size[4];
-        g_snprintf(size, 3, "%d", config.font_size);
-        g_setenv("PDC_FONT_SIZE", size, TRUE);
-    }
-#endif
     /* initialise the display - must not happen before this point
        otherwise displaying the command line help fails */
     display_init();

--- a/src/nlarn.c
+++ b/src/nlarn.c
@@ -75,7 +75,7 @@ static const char *save_file = "nlarn.sav";
 game *nlarn = NULL;
 
 /* the game settings */
-static struct game_config config = {};
+struct game_config config = {};
 
 /* death jump buffer - used to return to the main loop when the player has died */
 jmp_buf nlarn_death_jump;
@@ -1154,7 +1154,7 @@ int main(int argc, char *argv[])
         }
 
         /* automatic save point (not when restoring a save) */
-        if ((game_turn(nlarn) == 1) && game_autosave(nlarn))
+        if ((game_turn(nlarn) == 1) && !config.no_autosave)
         {
             game_save(nlarn);
         }
@@ -1163,6 +1163,8 @@ int main(int argc, char *argv[])
         mainloop();
     }
 
+    /* persist configuration before freeing it */
+    write_ini_file(nlarn_inifile, &config);
     free_config(config);
 
     return EXIT_SUCCESS;

--- a/src/player.c
+++ b/src/player.c
@@ -1561,7 +1561,7 @@ int player_map_enter(player *p, map *l, gboolean teleported)
     player_autopickup(p);
 
     /* automatic save point */
-    if (game_autosave(nlarn) && (game_turn(nlarn) > 1))
+    if (!config.no_autosave && (game_turn(nlarn) > 1))
     {
         game_save(nlarn);
     }


### PR DESCRIPTION
Full screen mode can be toggled with ALT-Enter. The overall experience
is quite nice, but the entire content of the application is shown in the
top right corner of the screen.

To finish this feature, I fear support from PDCurses is required to draw
the contents centered or even scale everything up to to use the
available space.

Closes #285