### PR TITLE
Fix bug triggered by unknown colors in display.c:display_get_colval()

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -44,6 +44,8 @@ const display_colset display_default_colset[] =
     { "magenta",      MAGENTA },
     { "cyan",         CYAN },
     { "lightgray",    LIGHTGRAY },
+    { "lightgrey",    LIGHTGRAY },
+    { "darkgray",     DARKGRAY },
     { "darkgrey",     DARKGRAY },
     { "lightred",     LIGHTRED },
     { "lightgreen",   LIGHTGREEN },
@@ -51,7 +53,8 @@ const display_colset display_default_colset[] =
     { "lightblue",    LIGHTBLUE },
     { "lightmagenta", LIGHTMAGENTA },
     { "lightcyan",    LIGHTCYAN },
-    { "white",        WHITE }
+    { "white",        WHITE },
+    { NULL,           0}
 };
 
 const display_colset display_dialog_colset[] =
@@ -64,6 +67,8 @@ const display_colset display_dialog_colset[] =
     { "magenta",      DDC_MAGENTA },
     { "cyan",         DDC_CYAN },
     { "lightgray",    DDC_LIGHTGRAY },
+    { "lightgrey",    DDC_LIGHTGRAY },
+    { "darkgray",     DDC_DARKGRAY },
     { "darkgrey",     DDC_DARKGRAY },
     { "lightred",     DDC_LIGHTRED },
     { "lightgreen",   DDC_LIGHTGREEN },
@@ -71,7 +76,8 @@ const display_colset display_dialog_colset[] =
     { "lightblue",    DDC_LIGHTBLUE },
     { "lightmagenta", DDC_LIGHTMAGENTA },
     { "lightcyan",    DDC_LIGHTCYAN },
-    { "white",        DDC_WHITE }
+    { "white",        DDC_WHITE },
+    { NULL,           0}
 };
 
 static gboolean display_initialised = FALSE;


### PR DESCRIPTION
Hi,
thanks for your great effort in keeping Larn alive! I played this game decades ago as a child.

I stumbled across a bug when [display_get_colval](https://github.com/nlarn/nlarn/blob/ebbbe77e56337c6f7c753e49c7bea3e2b1f74a92/src/display.c#L3064) tries to translate an unknown color such as `darkgray` into an `enum` value.  For information: the spelling variant `darkgray` is used at [here](https://github.com/nlarn/nlarn/blob/ebbbe77e56337c6f7c753e49c7bea3e2b1f74a92/src/player.c#L3915). The loop runs over the end of the array and crashes since the key `darkgray` is not found.

I have modified the structures `display_default_colset` and `display_dialog_colset` to use `NULL` guards at the end to catch future mistakes, and added aliases of the colors for spelling variants `gray` and `grey`.

Regards,
Daniel