### PR TITLE
Fixes required to compile with recent compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ LDFLAGS += $(shell pkg-config --libs glib-2.0)
 
 # Unless requested otherwise build with curses.
 ifneq ($(SDLPDCURSES),Y)
-	LDFLAGS += -lcurses -lpanel
+	LDFLAGS += $(shell pkg-config --libs ncurses) -lpanel
 else
 	PDCLIB   := PDCurses/sdl2/pdcurses.a
 	CFLAGS   += $(shell pkg-config --cflags SDL2_ttf) -IPDCurses -DSDLPDCURSES

--- a/inc/extdefs.h
+++ b/inc/extdefs.h
@@ -1,0 +1,50 @@
+/*
+ * nlarn.h
+ * Copyright (C) 2009-2020 Joachim de Groot <jdegroot@web.de>
+ *
+ * NLarn is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * NLarn is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __EXTDEFS_H_
+#define __EXTDEFS_H_
+
+#include <setjmp.h>
+
+#include "game.h"
+#include "position.h"
+
+/* game version string */
+extern const char *nlarn_version;
+
+/* the entire game */
+extern game *nlarn;
+
+/* death jump buffer - used to return to the main loop when the player has died */
+extern jmp_buf nlarn_death_jump;
+
+/* file paths */
+extern const char *nlarn_libdir;
+extern const char *nlarn_mesgfile;
+extern const char *nlarn_helpfile;
+extern const char *nlarn_mazefile;
+extern const char *nlarn_fortunes;
+extern const char *nlarn_highscores;
+extern const char *nlarn_inifile;
+extern const char *nlarn_savefile;
+
+extern const position pos_invalid;
+
+/* textual representation of the player's gender */
+extern const char *player_sex_str[PS_MAX];
+#endif

--- a/inc/player.h
+++ b/inc/player.h
@@ -79,9 +79,6 @@ typedef enum _player_sex
     PS_MAX
 } player_sex;
 
-/* textual representation of the player's gender */
-const char *player_sex_str[PS_MAX];
-
 typedef struct _player_settings
 {
     gboolean auto_pickup[IT_MAX]; /* automatically pick up item of enabled types */

--- a/inc/position.h
+++ b/inc/position.h
@@ -52,8 +52,6 @@ typedef union _position
     guint32 val;
 } position;
 
-const position pos_invalid;
-
 typedef struct _rectangle
 {
     guint64 x1: 16;

--- a/src/amulets.c
+++ b/src/amulets.c
@@ -19,7 +19,7 @@
 #include <glib.h>
 #include "amulets.h"
 #include "items.h"
-#include "nlarn.h"
+#include "extdefs.h"
 
 const amulet_data amulets[AM_MAX] =
 {

--- a/src/buildings.c
+++ b/src/buildings.c
@@ -25,7 +25,7 @@
 #include "game.h"
 #include "gems.h"
 #include "items.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "player.h"
 #include "scrolls.h"
 

--- a/src/config.c
+++ b/src/config.c
@@ -22,7 +22,7 @@
 
 #include "config.h"
 #include "display.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "items.h"
 #include "player.h"
 

--- a/src/container.c
+++ b/src/container.c
@@ -20,7 +20,7 @@
 
 #include "container.h"
 #include "display.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "player.h"
 #include "random.h"
 

--- a/src/display.c
+++ b/src/display.c
@@ -24,7 +24,7 @@
 #include "display.h"
 #include "fov.h"
 #include "map.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "spheres.h"
 
 typedef struct _display_colset

--- a/src/effects.c
+++ b/src/effects.c
@@ -22,7 +22,7 @@
 #include "cJSON.h"
 #include "effects.h"
 #include "game.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "random.h"
 
 static const effect_data effects[ET_MAX] =

--- a/src/fov.c
+++ b/src/fov.c
@@ -21,7 +21,7 @@
 #include "fov.h"
 #include "game.h"
 #include "map.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "position.h"
 
 static void fov_calculate_octant(fov *fv, map *m, position center,

--- a/src/game.c
+++ b/src/game.c
@@ -42,7 +42,7 @@
 #include "config.h"
 #include "display.h"
 #include "game.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "player.h"
 #include "spheres.h"
 #include "random.h"

--- a/src/inventory.c
+++ b/src/inventory.c
@@ -22,7 +22,7 @@
 #include "game.h"
 #include "inventory.h"
 #include "items.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "potions.h"
 
 /* functions */

--- a/src/items.c
+++ b/src/items.c
@@ -27,7 +27,7 @@
 #include "gems.h"
 #include "items.h"
 #include "map.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "player.h"
 #include "potions.h"
 #include "random.h"

--- a/src/map.c
+++ b/src/map.c
@@ -23,7 +23,7 @@
 #include "display.h"
 #include "items.h"
 #include "map.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "random.h"
 #include "sobjects.h"
 #include "spheres.h"

--- a/src/monsters.c
+++ b/src/monsters.c
@@ -26,7 +26,7 @@
 #include "items.h"
 #include "map.h"
 #include "monsters.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "pathfinding.h"
 #include "random.h"
 

--- a/src/nlarn.c
+++ b/src/nlarn.c
@@ -46,6 +46,7 @@
 #include "scoreboard.h"
 #include "sobjects.h"
 #include "traps.h"
+#include "extdefs.h"
 
 /* see https://stackoverflow.com/q/36764885/1519878 */
 #define _STR(x) #x

--- a/src/pathfinding.c
+++ b/src/pathfinding.c
@@ -16,7 +16,7 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "nlarn.h"
+#include "extdefs.h"
 #include "pathfinding.h"
 #include "player.h"
 

--- a/src/player.c
+++ b/src/player.c
@@ -27,13 +27,13 @@
 #include "display.h"
 #include "fov.h"
 #include "game.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "player.h"
 #include "random.h"
 #include "scoreboard.h"
 #include "sobjects.h"
 
-const char *player_sex_str[] = {"not defined", "male", "female"};
+const char *player_sex_str[PS_MAX] = {"not defined", "male", "female"};
 
 static const char aa1[] = "mighty evil master";
 static const char aa2[] = "apprentice demi-god";

--- a/src/position.c
+++ b/src/position.c
@@ -22,7 +22,7 @@
 #include "cJSON.h"
 #include "display.h"
 #include "map.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "position.h"
 
 #define POS_MAX_XY (1<<10)

--- a/src/potions.c
+++ b/src/potions.c
@@ -20,7 +20,7 @@
 
 #include "display.h"
 #include "game.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "player.h"
 #include "potions.h"
 #include "random.h"

--- a/src/rings.c
+++ b/src/rings.c
@@ -18,7 +18,7 @@
 
 #include <glib.h>
 
-#include "nlarn.h"
+#include "extdefs.h"
 #include "rings.h"
 
 const ring_data rings[RT_MAX] =

--- a/src/scoreboard.c
+++ b/src/scoreboard.c
@@ -25,7 +25,7 @@
 # include <sys/file.h>
 #endif
 
-#include "nlarn.h"
+#include "extdefs.h"
 #include "scoreboard.h"
 #include "cJSON.h"
 

--- a/src/scrolls.c
+++ b/src/scrolls.c
@@ -21,7 +21,7 @@
 
 #include "display.h"
 #include "game.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "random.h"
 #include "scrolls.h"
 

--- a/src/sobjects.c
+++ b/src/sobjects.c
@@ -21,7 +21,7 @@
 #include "display.h"
 #include "game.h"
 #include "map.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "sobjects.h"
 #include "player.h"
 #include "random.h"

--- a/src/spells.c
+++ b/src/spells.c
@@ -21,7 +21,7 @@
 
 #include "display.h"
 #include "map.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "random.h"
 #include "sobjects.h"
 #include "spells.h"

--- a/src/spheres.c
+++ b/src/spheres.c
@@ -19,7 +19,7 @@
 #include <glib.h>
 
 #include "game.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "random.h"
 #include "spheres.h"
 

--- a/src/traps.c
+++ b/src/traps.c
@@ -21,7 +21,7 @@
 #include "display.h"
 #include "effects.h"
 #include "game.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "player.h"
 #include "random.h"
 #include "traps.h"

--- a/src/utils.c
+++ b/src/utils.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "nlarn.h"
+#include "extdefs.h"
 #include "utils.h"
 
 static const guint LOG_MAX_LENGTH = 100;

--- a/src/weapons.c
+++ b/src/weapons.c
@@ -22,7 +22,7 @@
 #include "items.h"
 #include "map.h"
 #include "monsters.h"
-#include "nlarn.h"
+#include "extdefs.h"
 #include "player.h"
 #include "random.h"
 #include "weapons.h"


### PR DESCRIPTION
Recent compilers, such as gcc v10, complain rightfully that by including headers with variable declarations, e.g. nlarn.h, in global scope leads to redefinition of the same symbols. Declaring the respective variables once without extern and otherwise with solves this issue.
The second commit allows for more flexibility when dealing with systems that split ncurses into two libs, i.e., `ncurses` and `tinfo`.